### PR TITLE
upgrade-mocha-dependency-6.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "codecov": "^1.0.1",
     "istanbul": "^0.4.1",
-    "mocha": "^2.5.3"
+    "mocha": "^7.1.0"
   },
   "jspm": {
     "map": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "codecov": "^1.0.1",
     "istanbul": "^0.4.1",
-    "mocha": "^6.2.2"
+    "mocha": "^10.2.0"
   },
   "jspm": {
     "map": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "codecov": "^1.0.1",
     "istanbul": "^0.4.1",
-    "mocha": "^7.1.0"
+    "mocha": "^6.2.2"
   },
   "jspm": {
     "map": {


### PR DESCRIPTION
Upgrading mocha dependency to 6.2.2.
Should fix this [issue:](https://github.com/bestiejs/punycode.js/issues/101)
<img width="418" alt="Screen Shot 2020-03-16 at 18 27 43" src="https://user-images.githubusercontent.com/42721195/76779350-e232ac00-67b3-11ea-8e80-6d8b0fb31b54.png">
