### PR TITLE
Do not encode DEL

### DIFF
--- a/punycode.js
+++ b/punycode.js
@@ -15,7 +15,7 @@ const delimiter = '-'; // '\x2D'
 
 /** Regular expressions */
 const regexPunycode = /^xn--/;
-const regexNonASCII = /[^\0-\x7F]/; // non-ASCII chars
+const regexNonASCII = /[^\0-\x7F]/; // Note: U+007F DEL is excluded too.
 const regexSeparators = /[\x2E\u3002\uFF0E\uFF61]/g; // RFC 3490 separators
 
 /** Error messages */

--- a/punycode.js
+++ b/punycode.js
@@ -15,7 +15,7 @@ const delimiter = '-'; // '\x2D'
 
 /** Regular expressions */
 const regexPunycode = /^xn--/;
-const regexNonASCII = /[^\0-\x7E]/; // non-ASCII chars
+const regexNonASCII = /[^\0-\x7F]/; // non-ASCII chars
 const regexSeparators = /[\x2E\u3002\uFF0E\uFF61]/g; // RFC 3490 separators
 
 /** Error messages */


### PR DESCRIPTION
Node.js's [`url.domainToASCII()`](https://nodejs.org/api/url.html#url_url_domaintoascii_domain) does not encode [DEL](https://en.wikipedia.org/wiki/Delete_character) and this is the correct behavior according to [RFC 3490](https://datatracker.ietf.org/doc/html/rfc3490).

This patch updates the `regexNonASCII` range to include DEL.