### PR TITLE
Fix README falsely claiming browser support doesn't work

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This JavaScript library is the result of comparing, optimizing and documenting d
 
 This project was [bundled](https://github.com/joyent/node/blob/master/lib/punycode.js) with Node.js from [v0.6.2+](https://github.com/joyent/node/compare/975f1930b1...61e796decc) until [v7](https://github.com/nodejs/node/pull/7941) (soft-deprecated).
 
-This project provides a CommonJS module that uses ES6 features and an ES6 module, which work in modern Node versions and browsers. For the old version that offers the same functionality in a UMD build with support for older pre-ES6 runtimes, including Rhino, Ringo, and Narwhal, see [v1.4.1](https://github.com/bestiejs/punycode.js/releases/tag/v1.4.1).
+This project provides a CommonJS module that uses ES6 features and an ES module, which work in modern Node versions and browsers. For the old version that offers the same functionality in a UMD build with support for older pre-ES6 runtimes, including Rhino, Ringo, and Narwhal, see [v1.4.1](https://github.com/bestiejs/punycode.js/releases/tag/v1.4.1).
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This JavaScript library is the result of comparing, optimizing and documenting d
 
 This project was [bundled](https://github.com/joyent/node/blob/master/lib/punycode.js) with Node.js from [v0.6.2+](https://github.com/joyent/node/compare/975f1930b1...61e796decc) until [v7](https://github.com/nodejs/node/pull/7941) (soft-deprecated).
 
-The current version supports recent versions of Node.js only. It provides a CommonJS module and an ES6 module. For the old version that offers the same functionality with broader support, including Rhino, Ringo, Narwhal, and web browsers, see [v1.4.1](https://github.com/bestiejs/punycode.js/releases/tag/v1.4.1).
+This project provides a CommonJS module that uses ES6 features and an ES6 module, which work in modern Node versions and browsers. For the old version that offers the same functionality in a UMD build with support for older pre-ES6 runtimes, including Rhino, Ringo, and Narwhal, see [v1.4.1](https://github.com/bestiejs/punycode.js/releases/tag/v1.4.1).
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This JavaScript library is the result of comparing, optimizing and documenting d
 
 This project was [bundled](https://github.com/joyent/node/blob/master/lib/punycode.js) with Node.js from [v0.6.2+](https://github.com/joyent/node/compare/975f1930b1...61e796decc) until [v7](https://github.com/nodejs/node/pull/7941) (soft-deprecated).
 
-This project provides a CommonJS module that uses ES6 features and an ES module, which work in modern Node versions and browsers. For the old version that offers the same functionality in a UMD build with support for older pre-ES6 runtimes, including Rhino, Ringo, and Narwhal, see [v1.4.1](https://github.com/bestiejs/punycode.js/releases/tag/v1.4.1).
+This project provides a CommonJS module that uses ES2015+ features and JavaScript module, which work in modern Node.js versions and browsers. For the old Punycode.js version that offers the same functionality in a UMD build with support for older pre-ES2015 runtimes, including Rhino, Ringo, and Narwhal, see [v1.4.1](https://github.com/bestiejs/punycode.js/releases/tag/v1.4.1).
 
 ## Installation
 


### PR DESCRIPTION
The Readme currently claims that this project does not work in browsers, but this is wrong. I think the note in the Readme was originally meant to claim that the project no longer worked in pre-ES6 browsers, but that hasn't described any modern browsers for years now. This library works perfectly fine when used as directly a native ES6 module in browsers (try `await import('https://unpkg.com/punycode@2.1.1/punycode.es6.js')` in your browser console) or when used with a bundler like Webpack. (Webpack v5's [documentation even explicitly recommends](https://webpack.js.org/configuration/resolve/#resolvefallback) using this library as a shim for the Node "punycode" API when targeting browsers.)

This PR tweaks a line in the readme to emphasize that browser support does in fact work.