### PR TITLE
Do not decode non-ASCII-alphanumerics in Punycode labels

### DIFF
--- a/punycode.js
+++ b/punycode.js
@@ -142,13 +142,13 @@ const ucs2encode = codePoints => String.fromCodePoint(...codePoints);
  * the code point does not represent a value.
  */
 const basicToDigit = function(codePoint) {
-	if (codePoint - 0x30 < 0x0A) {
-		return codePoint - 0x16;
+	if (codePoint >= 0x30 && codePoint < 0x3A) {
+		return 26 + (codePoint - 0x30);
 	}
-	if (codePoint - 0x41 < 0x1A) {
+	if (codePoint >= 0x41 && codePoint < 0x5B) {
 		return codePoint - 0x41;
 	}
-	if (codePoint - 0x61 < 0x1A) {
+	if (codePoint >= 0x61 && codePoint < 0x7B) {
 		return codePoint - 0x61;
 	}
 	return base;
@@ -236,8 +236,11 @@ const decode = function(input) {
 			}
 
 			const digit = basicToDigit(input.charCodeAt(index++));
-
-			if (digit >= base || digit > floor((maxInt - i) / w)) {
+      
+			if (digit >= base) {
+				error('invalid-input');
+			}
+			if (digit > floor((maxInt - i) / w)) {
 				error('overflow');
 			}
 

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -295,6 +295,14 @@ describe('punycode.decode', function() {
 	it('handles uppercase Z', function() {
 		assert.deepEqual(punycode.decode('ZZZ'), '\u7BA5');
 	});
+	it('throws RangeError: Invalid input', function() {
+		assert.throws(
+			function() {
+				punycode.decode('ls8h=');
+			},
+			RangeError
+		);
+	});
 });
 
 describe('punycode.encode', function() {


### PR DESCRIPTION
Currently, invalid Punycode such as `ls8h=` will be successfully decoded. It should fail instead.

I think this comes about because `basicToDigit` was copied from C code in the punycode RFC, but that RFC uses _unsigned_ integers, whereas JS only has signed integers (AFAIK). We need to check that the result of, say, `codePoint - 0x30` is not negative -- or, as done here, check that `codePoint >= 0x30`.