### PR TITLE
Dependency upgrades for mitigating a vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,8 +44,8 @@
     "build": "node scripts/prepublish.js"
   },
   "devDependencies": {
-    "codecov": "^1.0.1",
-    "istanbul": "^0.4.1",
+    "codecov": "^3.8.3",
+    "nyc": "^15.1.0",
     "mocha": "^10.2.0"
   },
   "jspm": {


### PR DESCRIPTION
The codecov package had a vulnerability.

The istanbul package is no longer maintained. The project recommends switching to the nyc package, which was done.


The vulnerabilty, as per `npm audit`:
```
Severity: high
Command injection in codecov (npm package) - https://github.com/advisories/GHSA-xp63-6vf5-xf3v
codecov NPM module allows remote attackers to execute arbitrary commands - https://github.com/advisories/GHSA-5q88-cjfq-g2mh
Improper Neutralization of Special Elements in Output Used by a Downstream Component in Codecov - https://github.com/advisories/GHSA-mh2h-6j8q-x246
fix available via `npm audit fix --force`
Will install codecov@3.8.3, which is a breaking change
node_modules/codecov
```

Tests ran, all passed locally.