### PR TITLE
test: replace mocha with node.js builtin

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,13 +40,12 @@
     "punycode.es6.js"
   ],
   "scripts": {
-    "test": "mocha tests",
+    "test": "node --test",
     "build": "node scripts/prepublish.js"
   },
   "devDependencies": {
     "codecov": "^3.8.3",
-    "nyc": "^15.1.0",
-    "mocha": "^10.2.0"
+    "nyc": "^15.1.0"
   },
   "jspm": {
     "map": {

--- a/test.js
+++ b/test.js
@@ -1,6 +1,8 @@
 'use strict';
 
-const assert = require('assert');
+const assert = require('node:assert/strict')
+const { describe, it } = require('node:test')
+
 const punycode = require('../punycode.js');
 
 const testData = {


### PR DESCRIPTION
Note, it does change the output format somewhat:

```
 ✗ npm test

> punycode@2.3.1 test
> node --test

▶ punycode.ucs2.decode
  ✔ Consecutive astral symbols (0.429833ms)
  ✔ U+D800 (high surrogate) followed by non-surrogates (0.096ms)
  ✔ U+DC00 (low surrogate) followed by non-surrogates (0.036625ms)
  ✔ High surrogate followed by another high surrogate (0.037709ms)
  ✔ Unmatched high surrogate, followed by a surrogate pair, followed by an unmatched high surrogate (0.032542ms)
  ✔ Low surrogate followed by another low surrogate (0.027583ms)
  ✔ Unmatched low surrogate, followed by a surrogate pair, followed by an unmatched low surrogate (0.028625ms)
  ✔ throws RangeError: Illegal input >= 0x80 (not a basic code point) (0.329208ms)
  ✔ throws RangeError: Overflow: input needs wider integers to process (0.067958ms)
▶ punycode.ucs2.decode (2.553792ms)

▶ punycode.ucs2.encode
  ✔ Consecutive astral symbols (0.076333ms)
  ✔ U+D800 (high surrogate) followed by non-surrogates (0.030541ms)
  ✔ U+DC00 (low surrogate) followed by non-surrogates (0.024417ms)
  ✔ High surrogate followed by another high surrogate (0.019375ms)
  ✔ Unmatched high surrogate, followed by a surrogate pair, followed by an unmatched high surrogate (0.018709ms)
  ✔ Low surrogate followed by another low surrogate (0.017458ms)
  ✔ Unmatched low surrogate, followed by a surrogate pair, followed by an unmatched low surrogate (0.016666ms)
  ✔ does not mutate argument array (0.030583ms)
▶ punycode.ucs2.encode (0.4865ms)

▶ punycode.decode
  ✔ a single basic code point (0.096666ms)
  ✔ a single non-ASCII character (0.063291ms)
  ✔ multiple non-ASCII characters (0.0955ms)
  ✔ mix of ASCII and non-ASCII characters (0.0215ms)
  ✔ long string with both ASCII and non-ASCII characters (0.023ms)
  ✔ Arabic (Egyptian) (0.0215ms)
  ✔ Chinese (simplified) (0.020208ms)
  ✔ Chinese (traditional) (0.020792ms)
  ✔ Czech (0.331791ms)
  ✔ Hebrew (0.038584ms)
  ✔ Hindi (Devanagari) (0.0285ms)
  ✔ Japanese (kanji and hiragana) (0.024334ms)
  ✔ Korean (Hangul syllables) (0.027459ms)
  ✔ Russian (Cyrillic) (0.024708ms)
  ✔ Spanish (0.020209ms)
  ✔ Vietnamese (0.020708ms)
  ✔ 3B-ww4c5e180e575a65lsy2b (0.020375ms)
  ✔ -with-SUPER-MONKEYS-pc58ag80a8qai00g7n9n (0.11975ms)
  ✔ Hello-Another-Way--fc4qua05auwb3674vfr0b (0.020459ms)
  ✔ 2-u9tlzr9756bt3uc0v (0.021166ms)
  ✔ MajiKoi5-783gue6qz075azm5e (0.019125ms)
  ✔ de-jg4avhby1noc0d (0.018417ms)
  ✔ d9juau41awczczp (0.01825ms)
  ✔ ASCII string that breaks the existing rules for host-name labels (0.016542ms)
  ✔ handles uppercase Z (0.035416ms)
  ✔ throws RangeError: Invalid input (0.04525ms)
▶ punycode.decode (1.693334ms)

▶ punycode.encode
  ✔ a single basic code point (0.168208ms)
  ✔ a single non-ASCII character (0.029375ms)
  ✔ multiple non-ASCII characters (0.092959ms)
  ✔ mix of ASCII and non-ASCII characters (0.022375ms)
  ✔ long string with both ASCII and non-ASCII characters (0.028334ms)
  ✔ Arabic (Egyptian) (0.031125ms)
  ✔ Chinese (simplified) (0.023417ms)
  ✔ Chinese (traditional) (0.023583ms)
  ✔ Czech (0.022625ms)
  ✔ Hebrew (0.037458ms)
  ✔ Hindi (Devanagari) (0.046333ms)
  ✔ Japanese (kanji and hiragana) (0.037042ms)
  ✔ Korean (Hangul syllables) (0.054208ms)
  ✔ Russian (Cyrillic) (0.045625ms)
  ✔ Spanish (0.029084ms)
  ✔ Vietnamese (0.033458ms)
  ✔ 3年B組金八先生 (0.024292ms)
  ✔ 安室奈美恵-with-SUPER-MONKEYS (0.027334ms)
  ✔ Hello-Another-Way-それぞれの場所 (0.028208ms)
  ✔ ひとつ屋根の下2 (0.025ms)
  ✔ MajiでKoiする5秒前 (0.024417ms)
  ✔ パフィーdeルンバ (0.024292ms)
  ✔ そのスピードで (0.021666ms)
  ✔ ASCII string that breaks the existing rules for host-name labels (0.018541ms)
▶ punycode.encode (1.234ms)

▶ punycode.toUnicode
  ✔ xn--maana-pta.com (0.42875ms)
  ✔ example.com. (0.048083ms)
  ✔ xn--bcher-kva.com (0.034875ms)
  ✔ xn--caf-dma.com (0.031167ms)
  ✔ xn----dqo34k.com (0.028333ms)
  ✔ xn----dqo34kn65z.com (0.027708ms)
  ✔ Emoji (0.023709ms)
  ✔ Non-printable ASCII (0.021542ms)
  ✔ Email address (0.140625ms)
  ✔ foo.example (0.025917ms)
  ✔ does not convert names (or other strings) that don't start with `xn--` (0.045542ms)
  ✔ does not convert names (or other strings) that don't start with `xn--` (0.020292ms)
  ✔ does not convert names (or other strings) that don't start with `xn--` (0.03425ms)
  ✔ does not convert names (or other strings) that don't start with `xn--` (0.038833ms)
  ✔ does not convert names (or other strings) that don't start with `xn--` (0.01975ms)
  ✔ does not convert names (or other strings) that don't start with `xn--` (0.022042ms)
  ✔ does not convert names (or other strings) that don't start with `xn--` (0.019208ms)
  ✔ does not convert names (or other strings) that don't start with `xn--` (0.021583ms)
  ✔ does not convert names (or other strings) that don't start with `xn--` (0.019208ms)
  ✔ does not convert names (or other strings) that don't start with `xn--` (0.018625ms)
  ✔ does not convert names (or other strings) that don't start with `xn--` (0.018833ms)
  ✔ does not convert names (or other strings) that don't start with `xn--` (0.018375ms)
  ✔ does not convert names (or other strings) that don't start with `xn--` (0.390833ms)
  ✔ does not convert names (or other strings) that don't start with `xn--` (0.052458ms)
  ✔ does not convert names (or other strings) that don't start with `xn--` (0.019334ms)
  ✔ does not convert names (or other strings) that don't start with `xn--` (0.01875ms)
  ✔ does not convert names (or other strings) that don't start with `xn--` (0.023375ms)
  ✔ does not convert names (or other strings) that don't start with `xn--` (0.019125ms)
  ✔ does not convert names (or other strings) that don't start with `xn--` (0.019292ms)
  ✔ does not convert names (or other strings) that don't start with `xn--` (0.015917ms)
  ✔ does not convert names (or other strings) that don't start with `xn--` (0.015208ms)
  ✔ does not convert names (or other strings) that don't start with `xn--` (0.015375ms)
  ✔ does not convert names (or other strings) that don't start with `xn--` (0.019084ms)
  ✔ does not convert names (or other strings) that don't start with `xn--` (0.016666ms)
▶ punycode.toUnicode (2.2975ms)

▶ punycode.toASCII
  ✔ mañana.com (0.188542ms)
  ✔ example.com. (0.017875ms)
  ✔ bücher.com (0.018959ms)
  ✔ café.com (0.018333ms)
  ✔ ☃-⌘.com (0.033708ms)
  ✔ 퐀☃-⌘.com (0.023292ms)
  ✔ Emoji (0.023ms)
  ✔ Non-printable ASCII (0.019542ms)
  ✔ Email address (0.092583ms)
  ✔ foo.example (0.019917ms)
  ✔ does not convert domain names (or other strings) that are already in ASCII (0.029125ms)
  ✔ does not convert domain names (or other strings) that are already in ASCII (0.013708ms)
  ✔ does not convert domain names (or other strings) that are already in ASCII (0.022792ms)
  ✔ does not convert domain names (or other strings) that are already in ASCII (0.013416ms)
  ✔ does not convert domain names (or other strings) that are already in ASCII (0.017042ms)
  ✔ does not convert domain names (or other strings) that are already in ASCII (0.013583ms)
  ✔ does not convert domain names (or other strings) that are already in ASCII (0.013459ms)
  ✔ does not convert domain names (or other strings) that are already in ASCII (0.013125ms)
  ✔ does not convert domain names (or other strings) that are already in ASCII (0.013875ms)
  ✔ does not convert domain names (or other strings) that are already in ASCII (0.015917ms)
  ✔ does not convert domain names (or other strings) that are already in ASCII (0.013375ms)
  ✔ does not convert domain names (or other strings) that are already in ASCII (0.012875ms)
  ✔ does not convert domain names (or other strings) that are already in ASCII (0.013667ms)
  ✔ does not convert domain names (or other strings) that are already in ASCII (0.013083ms)
  ✔ does not convert domain names (or other strings) that are already in ASCII (0.01625ms)
  ✔ does not convert domain names (or other strings) that are already in ASCII (0.013916ms)
  ✔ does not convert domain names (or other strings) that are already in ASCII (0.016292ms)
  ✔ does not convert domain names (or other strings) that are already in ASCII (0.015291ms)
  ✔ does not convert domain names (or other strings) that are already in ASCII (0.014208ms)
  ✔ does not convert domain names (or other strings) that are already in ASCII (0.014417ms)
  ✔ does not convert domain names (or other strings) that are already in ASCII (0.014375ms)
  ✔ does not convert domain names (or other strings) that are already in ASCII (0.015167ms)
  ✔ does not convert domain names (or other strings) that are already in ASCII (0.014458ms)
  ✔ does not convert domain names (or other strings) that are already in ASCII (0.013709ms)
  ✔ supports IDNA2003 separators for backwards compatibility (0.024958ms)
  ✔ supports IDNA2003 separators for backwards compatibility (0.017959ms)
  ✔ supports IDNA2003 separators for backwards compatibility (0.01775ms)
  ✔ supports IDNA2003 separators for backwards compatibility (0.018542ms)
▶ punycode.toASCII (1.480084ms)

ℹ tests 139
ℹ suites 6
ℹ pass 139
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 79.994041
```