### PR TITLE
add esmodule support

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "A robust Punycode converter that fully complies to RFC 3492 and RFC 5891, and works on nearly all JavaScript platforms.",
   "homepage": "https://mths.be/punycode",
   "main": "punycode.js",
-  "jsnext:main": "punycode.es6.js",
-  "module": "punycode.es6.js",
+  "jsnext:main": "punycode.mjs",
+  "module": "punycode.mjs",
   "engines": {
     "node": ">=6"
   },

--- a/scripts/prepublish.js
+++ b/scripts/prepublish.js
@@ -15,3 +15,4 @@ if (!regex.test(sourceContents)) {
 const outputContents = sourceContents.replace(regex, output);
 
 fs.writeFileSync(path.resolve(__dirname, '../punycode.es6.js'), outputContents);
+fs.writeFileSync(path.resolve(__dirname, '../punycode.es6.mjs'), outputContents);

--- a/scripts/prepublish.js
+++ b/scripts/prepublish.js
@@ -15,4 +15,4 @@ if (!regex.test(sourceContents)) {
 const outputContents = sourceContents.replace(regex, output);
 
 fs.writeFileSync(path.resolve(__dirname, '../punycode.es6.js'), outputContents);
-fs.writeFileSync(path.resolve(__dirname, '../punycode.es6.mjs'), outputContents);
+fs.writeFileSync(path.resolve(__dirname, '../punycode.mjs'), outputContents);


### PR DESCRIPTION
Since using esmodule in node.js requires `.mjs`, this PR changes to generate `.mjs` along with `punycode.es6.js`

Closes #116